### PR TITLE
GB-25 style: color-chip 설정

### DIFF
--- a/fe/tailwind.config.js
+++ b/fe/tailwind.config.js
@@ -9,7 +9,18 @@ module.exports = {
     './src/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'y-brown': '#CD5F03',
+        'y-cream': '#FCF2E9',
+        'y-gold': '#F1B31C',
+        'y-lightGray': '#DDDDDD',
+        'y-yellow': '#FCEA2B',
+        'y-lemon': '#FFFBD4',
+        'y-gray': '#A7A7A7',
+        'y-black': '#000000',
+      },
+    },
   },
   plugins: [],
 };

--- a/fe/tsconfig.json
+++ b/fe/tsconfig.json
@@ -16,7 +16,7 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
1. tailwind.config.js 에 컬러칩 설정해두었습니다.
<img width="446" alt="image" src="https://user-images.githubusercontent.com/107970881/215114299-2d11c63b-a96c-404a-b8d5-f7e545194fdd.png">
<img width="258" alt="image" src="https://user-images.githubusercontent.com/107970881/215114611-b85a871f-c09c-47c2-a5d2-0e6311b1c7a5.png">

