### PR TITLE
GB-98: 프로필 이미지 수정

### DIFF
--- a/fe/components/Alarm.tsx
+++ b/fe/components/Alarm.tsx
@@ -1,5 +1,6 @@
-import { VscBell, VscBellDot } from 'react-icons/vsc';
 import { FiBellOff } from 'react-icons/fi';
+import { CgBell } from 'react-icons/cg';
+
 import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { accessToken } from '@/atoms/login';
@@ -137,11 +138,11 @@ export default function Alarm() {
       <div onClick={() => setShowModal(true)}>
         {isLogin && alarmList && alarmList.length > 0 ? (
           <div className="relative">
-            <VscBellDot className=" w-[28px] h-[28px]" />
-            <span className="absolute top-[1px] right-[1px] w-[11px] h-[11px] rounded-full bg-y-brown"></span>
+            <CgBell className=" w-[28px] h-[28px]" />
+            <span className="absolute top-0.5 right-0.5 w-[9px] h-[9px] rounded-full bg-y-brown"></span>
           </div>
         ) : isLogin ? (
-          <VscBell className="w-[28px] h-[28px]" />
+          <CgBell className="w-[28px] h-[28px]" />
         ) : (
           <></>
         )}
@@ -173,8 +174,8 @@ export default function Alarm() {
                   ))}
                 </>
               ) : (
-                <li className="text-[8px] text-y-brown px-4 py-1 lg:text-xs truncate">
-                  <FiBellOff className="w-4 h-4 inline" />
+                <li className="text-[8px] text-y-gray px-4 lg:text-xs truncate">
+                  <FiBellOff className="w-4 h-4 m-auto mb-1" />
                   알림이 없습니다.
                 </li>
               )}

--- a/fe/components/Alarm.tsx
+++ b/fe/components/Alarm.tsx
@@ -165,7 +165,7 @@ export default function Alarm() {
                         src={el?.commentUserImage}
                         width={10}
                         height={10}
-                        className="w-4 h-4 inline mr-1"
+                        className="w-4 h-4 inline mr-1 rounded-full"
                         priority
                       />
                       <span>{el.title}</span>

--- a/fe/components/middleCards/RatingCard.tsx
+++ b/fe/components/middleCards/RatingCard.tsx
@@ -76,7 +76,7 @@ export default function RatingCard(props: {
               alt="user profile image"
               src={props.cardProps.userImage}
               fill
-              className="object-cover"
+              className="object-cover rounded-full"
             />
           </div>
           <div className="flex flex-col ml-2 text-xs">

--- a/fe/components/pairing/PairingCard.tsx
+++ b/fe/components/pairing/PairingCard.tsx
@@ -115,7 +115,7 @@ export default function PairingCard(props: { pairingCardProps: any }) {
                 </>
               ) : (
                 <div
-                  className="text-xs leading-6 h-fit"
+                  className="text-xs leading-6 h-fit px-2"
                   id={`myDescribe${props?.pairingCardProps?.pairingId}`}
                 >
                   {props?.pairingCardProps?.content}
@@ -170,7 +170,7 @@ export default function PairingCard(props: { pairingCardProps: any }) {
         </div>
       </Link>
       {/* 코멘트수,엄지수 */}
-      <div className="flex justify-end mr-1">
+      <div className="flex justify-end mr-3 mb-3">
         <div className="flex justify-center items-center">
           <HiOutlineChat />
           <span className="text-xs ml-0.5 mr-2 mt-0.5">

--- a/fe/components/pairing/PairingCardController.tsx
+++ b/fe/components/pairing/PairingCardController.tsx
@@ -33,7 +33,7 @@ export default function PairingCardController(props: {
           {cardPropsList?.map((el: any, idx: number) => (
             <div
               key={idx}
-              className="rounded-lg bg-white text-y-black text-xs border-2 mx-2 mt-3 relative"
+              className="rounded-lg bg-white text-y-black text-xs border mx-2 mt-3 relative"
             >
               {/*닉네임, 날짜*/}
               <ProfileCard

--- a/fe/components/pairing/ProfileCard.tsx
+++ b/fe/components/pairing/ProfileCard.tsx
@@ -11,11 +11,11 @@ export default function ProfileCard(props: {
         <></>
       ) : (
         <Image
-          alt="userImg rounded-full"
+          alt="userImg"
           src={props?.userImage}
           width={100}
           height={100}
-          className="w-7 h-7 mr-1"
+          className="w-7 h-7 mr-1 rounded-full"
           priority
         />
       )}

--- a/fe/components/smallCards/PopularBeer.tsx
+++ b/fe/components/smallCards/PopularBeer.tsx
@@ -18,6 +18,10 @@ export default function PopularBeer({ popularBeer }: any) {
 
   return (
     <div className="w-full ">
+      <div className="m-3 mt-6 text-base font-semibold lg:text-xl">
+        <span className="text-y-brown mr-1">인기 많은</span>
+        <span className="text-black">맥주</span>
+      </div>
       <Swiper
         className="w-full h-fit"
         slidesPerView={2.4}

--- a/fe/components/smallCards/SimilarBeer.tsx
+++ b/fe/components/smallCards/SimilarBeer.tsx
@@ -19,8 +19,8 @@ export default function SimilarBeer({ similarBeer }: any) {
   return (
     <div className="w-full ">
       <div className="mx-3 mt-6 text-base font-semibold lg:text-xl">
-        <span className="text-black mr-1">비슷한</span>
-        <span className="text-y-brown">맥주</span>
+        <span className="text-y-brown mr-1">비슷한</span>
+        <span className="text-black">맥주</span>
       </div>
       <Swiper
         className="w-full h-fit"

--- a/fe/components/smallCards/SmallPairingCard.tsx
+++ b/fe/components/smallCards/SmallPairingCard.tsx
@@ -93,7 +93,7 @@ export default function SmallPairingCard({ pairingProps }: any) {
                 src={pairingList?.userImage}
                 width={100}
                 height={100}
-                className="w-4 h-4"
+                className="w-4 h-4 rounded-full"
                 priority
               />
             ) : (

--- a/fe/components/smallCards/SmallRatingCard.tsx
+++ b/fe/components/smallCards/SmallRatingCard.tsx
@@ -162,7 +162,7 @@ export default function SmallRatingCard({ ratingProps }: any) {
                 alt="userImg"
                 width={100}
                 height={100}
-                className="w-4 h-4"
+                className="w-4 h-4 rounded-full"
                 priority
               />
             )}

--- a/fe/pages/beer/[id].tsx
+++ b/fe/pages/beer/[id].tsx
@@ -63,7 +63,7 @@ export default function Beer() {
         .get(`/api/ratings/page/mostlikes?beerId=${curRoute}&page=1&size=5`)
         .then((response) => {
           setRatingInfo(response.data);
-          if (USERID === response.data.data[0].userId) {
+          if (USERID === response?.data?.data[0]?.userId) {
             setHasRating(true);
             setMyRatingId(response.data.data[0].ratingId);
           } else {

--- a/fe/pages/index.tsx
+++ b/fe/pages/index.tsx
@@ -56,10 +56,6 @@ export default function Main() {
             <></>
           ) : (
             <>
-              <div className="m-3 mt-6 text-base font-semibold lg:text-xl">
-                <span className="text-y-brown mr-1">인기 많은</span>
-                <span className="text-black">맥주</span>
-              </div>
               <PopularBeer popularBeer={popularBeer} />
             </>
           )}

--- a/fe/pages/mypage/pairing.tsx
+++ b/fe/pages/mypage/pairing.tsx
@@ -52,7 +52,7 @@ export default function Pairing() {
         {pariginCardPops?.length ? (
           <Pagenation page={page} setPage={setPage} totalPages={totalPages} />
         ) : (
-          <div className="flex flex-col justify-center items-center rounded-lg bg-y-lightGray py-5 m-2">
+          <div className="noneContent py-8">
             <Image
               className="m-auto pb-3 opacity-50"
               src="/images/logo.png"
@@ -60,7 +60,7 @@ export default function Pairing() {
               width={40}
               height={40}
             />
-            <span>등록된 페어링이 없습니다</span>
+            등록된 페어링이 없습니다.
           </div>
         )}
         <div className="pb-24"></div>

--- a/fe/pages/mypage/wish.tsx
+++ b/fe/pages/mypage/wish.tsx
@@ -12,7 +12,7 @@ import Pagenation from '@/components/Pagenation';
 export default function Wish() {
   const [wishList, setWishList] = useState<any>([]);
   const [page, setPage] = useState<number>(1);
-  const [totalPages, setTotalPages] = useState<number>(1);
+  const [totalPages, setTotalPages] = useState<number>(0);
   const [TOKEN] = useRecoilState(accessToken);
   const [username] = useRecoilState(userNickname);
   const router = useRouter();
@@ -53,7 +53,7 @@ export default function Wish() {
           </div>
 
           {wishList.length === 0 ? (
-            <div className="noneContent py-32">
+            <div className="noneContent py-8">
               <Image
                 className="m-auto pb-3 opacity-50"
                 src="/images/logo.png"
@@ -70,7 +70,12 @@ export default function Wish() {
               ))}
             </div>
           )}
-          <Pagenation page={page} setPage={setPage} totalPages={totalPages} />
+          {totalPages === 0 ? (
+            <></>
+          ) : (
+            <Pagenation page={page} setPage={setPage} totalPages={totalPages} />
+          )}
+
           <div className="pb-14"></div>
         </div>
       </main>

--- a/fe/pages/pairing/[id].tsx
+++ b/fe/pages/pairing/[id].tsx
@@ -45,6 +45,7 @@ export default function PairingDetail() {
           setPairingProps(response.data);
           setPairingCommentList(response.data.commentList);
           if (response.data.userId === USERID) {
+            console.log(response.data);
             setIsMine(true);
           }
         })

--- a/fe/pages/pairing/[id].tsx
+++ b/fe/pages/pairing/[id].tsx
@@ -137,7 +137,7 @@ export default function PairingDetail() {
               }
             />
           </div>
-          <div>
+          <div className="mr-3">
             {pairingCommentList === null
               ? null
               : pairingCommentList.map((el) => {


### PR DESCRIPTION
- 프로필 이미지 동구라밍
- 알림 컴포넌트 이동
- 결과는 경우는 하얀 배경
- 페어링 댓글 말풍선 부모 div mr-3
- 페어링 border-1 
- 좌우 margin 2  
- 페어링 좋아여 mb 세린님께 맞추기 
- 위시 페이지  없는 경우 페이지 네이션 안보이도록
- 아이콘 두꺼운 알람으로 
- '비슷한' 맥주 
